### PR TITLE
Dynamic widths

### DIFF
--- a/css/ui.multiselect.css
+++ b/css/ui.multiselect.css
@@ -11,8 +11,9 @@
 .ui-multiselect ul.selected { position: relative; padding: 0; overflow: auto; overflow-x: hidden; background: #fff; margin: 0; list-style: none; border: 0; position: relative; width: 100%; }
 .ui-multiselect ul.selected li { }
 
-.ui-multiselect div.available { position: relative; padding: 0; margin: 0; border: 0; float:left; border-left: 1px solid; }
-.ui-multiselect ul.available { position: relative; padding: 0; overflow: auto; overflow-x: hidden; background: #fff; margin: 0; list-style: none; border: 0; width: 100%; }
+.ui-multiselect div.available { position: relative; padding: 0; margin: 0; border: 0; float:left; }
+.ui-multiselect div.available .actions, .ui-multiselect ul.available { border-left: 1px solid; }
+.ui-multiselect ul.available { position: relative; padding: 0; overflow: auto; overflow-x: hidden; background: #fff; margin: 0; list-style: none; width: 100%; }
 .ui-multiselect ul.available li { padding-left: 10px; }
  
 .ui-multiselect .ui-state-default { border: none; margin-bottom: 1px; position: relative; padding-left: 20px;}

--- a/js/ui.multiselect.js
+++ b/js/ui.multiselect.js
@@ -57,9 +57,9 @@ $.widget("ui.multiselect", {
 		var that = this;
 
 		// set dimensions
-		this.container.width(this.element.width()+1);
-		this.selectedContainer.width(Math.floor(this.element.width()*this.options.dividerLocation));
-		this.availableContainer.width(Math.floor(this.element.width()*(1-this.options.dividerLocation)));
+		this.container.width('100%');
+		this.selectedContainer.width(Math.floor(100*this.options.dividerLocation)+'%');
+		this.availableContainer.width(Math.floor(100*(1-this.options.dividerLocation))+'%');
 
 		// fix list height to match <option> depending on their individual header's heights
 		this.selectedList.height(Math.max(this.element.height()-this.selectedActions.height(),1));
@@ -285,8 +285,8 @@ $.widget("ui.multiselect", {
   			$(this).parent().draggable({
   	      connectToSortable: that.selectedList,
   				helper: function() {
-  					var selectedItem = that._cloneWithData($(this)).width($(this).width() - 50);
-  					selectedItem.width($(this).width());
+  					var selectedItem = that._cloneWithData($(this));
+  					selectedItem.width('100%');
   					return selectedItem;
   				},
   				appendTo: that.container,


### PR DESCRIPTION
Replacing explicit width values with relative % values, to allow for a dynamic design.

To see the effect in the demo, you can remove the width attribute of div#wrapper and then resize the browser.

Note that a fix to the demo would be required so it looks the same as before (probably wrapping it in a fixed width element).
Possible improvement: allow passing width as a parameter (to override '100%').
