### PR TITLE
Using '+' sign will not maintain ordering of list

### DIFF
--- a/js/ui.multiselect.js
+++ b/js/ui.multiselect.js
@@ -174,7 +174,9 @@ $.widget("ui.multiselect", {
 		return clone;
 	},
 	_setSelected: function(item, selected) {
-		item.data('optionLink').attr('selected', selected);
+		var addedNode = item.data('optionLink').attr('selected', selected);
+		var parent = addedNode.parent();
+		addedNode.detach().appendTo (parent);
 
 		if (selected) {
 			var selectedItem = this._cloneWithData(item);


### PR DESCRIPTION
If you use the + sign to add element from the available list, the order of the submitted fields will not be maintained. This commit will fix it.
