### PR TITLE
Selected option order issue resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
-h2. jQuery UI Multiselect
+## jQuery UI Multiselect
 
 This repository is no longer actively maintained by the author. However, pull requests are always welcome. If there's someone interested in officially maintaining the plugin, please let me know.
 
 In case you are looking for an AJAX version, please also consider "Yanick Rochon's":http://github.com/michael/multiselect/tree/next version, or also check the official "version 2.0":https://github.com/yanickrochon/jquery.uix.multiselect currently in development.
+
+To get the order of the selected items as selected, you can do like
+```javascript
+var form = $("form#my_form");
+$(form).on('submit', function(){
+	$("ul.selected li").each(function(){
+		var selected_value = $(this).attr('data-selected-value');
+		if(selected_value){
+			$(form).append("<input type='hidden' value='" + selected_value + "' name='selected_items_values_in_order[]' />");
+		}
+	});
+});
+```

--- a/js/ui.multiselect.js
+++ b/js/ui.multiselect.js
@@ -163,7 +163,7 @@ $.widget("ui.multiselect", {
 	},
 	_getOptionNode: function(option) {
 		option = $(option);
-		var node = $('<li class="ui-state-default ui-element" title="'+option.text()+'"><span class="ui-icon"/>'+option.text()+'<a href="#" class="action"><span class="ui-corner-all ui-icon"/></a></li>').hide();
+		var node = $('<li class="ui-state-default ui-element" title="'+option.text()+'" data-selected-value="' + option.val() + '"><span class="ui-icon"/>'+option.text()+'<a href="#" class="action"><span class="ui-corner-all ui-icon"/></a></li>').hide();
 		node.data('optionLink', option);
 		return node;
 	},


### PR DESCRIPTION
Previously, before this commit there was no way to get the selected values in order. Now, it's possible to get that with example attached to the readme.