### PR TITLE
#171 HTML encode <li> element attributes and content

### DIFF
--- a/js/ui.multiselect.js
+++ b/js/ui.multiselect.js
@@ -163,7 +163,14 @@ $.widget("ui.multiselect", {
 	},
 	_getOptionNode: function(option) {
 		option = $(option);
-		var node = $('<li class="ui-state-default ui-element" title="'+option.text()+'" data-selected-value="' + option.val() + '"><span class="ui-icon"/>'+option.text()+'<a href="#" class="action"><span class="ui-corner-all ui-icon"/></a></li>').hide();
+		var node = $('<li>',
+			{
+				class: 'ui-state-default ui-element',
+				title: option.text(),
+				'data-selected-value': option.val()
+			})
+			.append('<span class="ui-icon"/>'+option.html()+'<a href="#" class="action"><span class="ui-corner-all ui-icon"/></a></li>')
+			.hide();
 		node.data('optionLink', option);
 		return node;
 	},


### PR DESCRIPTION
Use available jQuery features to set the \<li\> element attributes and content instead of using string concatenation to construct the jQuery object directly from a raw HTML string.  This ensures that the \<li\> element attributes and content are appropriately encoded from the source \<option\> element attributes.  This change resolve the problems reported in issue #171.